### PR TITLE
Release (quick fix for tabletimetable showing wrong day)

### DIFF
--- a/templates/vauhtijuoksu/plugins/tabletimetable.html
+++ b/templates/vauhtijuoksu/plugins/tabletimetable.html
@@ -6,7 +6,7 @@
         </div>
         {% for day in games %}
             <div class="tttday">
-                {{ day.0.start_time|date:"w"|fiweekday }} {{ day.0.start_time|date:"j.n." }}
+                {{ day.1.start_time|date:"w"|fiweekday }} {{ day.1.start_time|date:"j.n." }}
             </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
The first game of the day might come from previous day so it will show the wrong date... this fix is a bit dirty but works for now. It will only break if there is a day with only 1 game...