### PR TITLE
Release - static image references

### DIFF
--- a/.github/workflows/azure-deployment.yml
+++ b/.github/workflows/azure-deployment.yml
@@ -8,7 +8,10 @@ on:
   push:
     branches:
       - trunk
-  workflow_dispatch:
+      - develop
+
+env:
+  DEPLOYMENT_SLOT: ${{ contains(github.ref, 'trunk') && 'Production' || 'Staging' }}
 
 jobs:
   build:
@@ -44,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: 'Production'
+      name: env.DEPLOYMENT_SLOT
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:
@@ -59,5 +62,5 @@ jobs:
         id: deploy-to-webapp
         with:
           app-name: 'vauhtijuoksu-cms-dev'
-          slot-name: 'Production'
+          slot-name: env.DEPLOYMENT_SLOT
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_3CE4CF36C08540C9B1F9CA3133282B67 }}

--- a/.github/workflows/azure-deployment.yml
+++ b/.github/workflows/azure-deployment.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: env.DEPLOYMENT_SLOT
+      name: ${{ env.DEPLOYMENT_SLOT }}
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:
@@ -62,5 +62,5 @@ jobs:
         id: deploy-to-webapp
         with:
           app-name: 'vauhtijuoksu-cms-dev'
-          slot-name: env.DEPLOYMENT_SLOT
+          slot-name: ${{ env.DEPLOYMENT_SLOT }}
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_3CE4CF36C08540C9B1F9CA3133282B67 }}

--- a/.github/workflows/azure-deployment.yml
+++ b/.github/workflows/azure-deployment.yml
@@ -85,6 +85,6 @@ jobs:
           app-name: 'vauhtijuoksu-cms-dev'
           slot-name: staging
           publish-profile:
-            ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_3CE4CF36C08540C9B1F9CA3133282B67 }}ging:
+            ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_3CE4CF36C08540C9B1F9CA3133282B67 }}
 
 

--- a/.github/workflows/azure-deployment.yml
+++ b/.github/workflows/azure-deployment.yml
@@ -10,9 +10,6 @@ on:
       - trunk
       - develop
 
-env:
-  DEPLOYMENT_SLOT: ${{ contains(github.ref, 'trunk') && 'Production' || 'Staging' }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -43,11 +40,12 @@ jobs:
             . 
             !venv/
 
-  deploy:
+  deploy-prod:
+    if: github.ref == 'refs/heads/trunk'
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: ${{ env.DEPLOYMENT_SLOT }}
+      name: Production
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:
@@ -62,5 +60,31 @@ jobs:
         id: deploy-to-webapp
         with:
           app-name: 'vauhtijuoksu-cms-dev'
-          slot-name: ${{ env.DEPLOYMENT_SLOT }}
+          slot-name: Production
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_3CE4CF36C08540C9B1F9CA3133282B67 }}
+
+  deploy-staging:
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: Staging
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+
+    steps:
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: python-app
+          path: .
+
+      - name: 'Deploy to Azure App Service Staging slot'
+        uses: azure/webapps-deploy@v2
+        id: deploy-to-webapp
+        with:
+          app-name: 'vauhtijuoksu-cms-dev'
+          slot-name: staging
+          publish-profile:
+            ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_3CE4CF36C08540C9B1F9CA3133282B67 }}ging:
+
+

--- a/.github/workflows/azure-deployment.yml
+++ b/.github/workflows/azure-deployment.yml
@@ -85,6 +85,6 @@ jobs:
           app-name: 'vauhtijuoksu-cms-dev'
           slot-name: staging
           publish-profile:
-            ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_3CE4CF36C08540C9B1F9CA3133282B67 }}
+            ${{ secrets.AZUREAPPSERVICE_STAGING_PUBLISHPROFILE }}
 
 

--- a/templates/vauhtijuoksu/plugins/divider.html
+++ b/templates/vauhtijuoksu/plugins/divider.html
@@ -1,12 +1,2 @@
 {% load static %}
-{% if number == 0 %}
-  <img class="divider" alt="divider" src="{% static 'vauhtijuoksu2021plus/img/divider_0.png' %}">
-{% elif number == 1 %}
-  <img class="divider"  alt="divider" src="{% static 'vauhtijuoksu2021plus/img/divider_1.png' %}">
-{% elif number == 2 %}
-  <img class="divider"  alt="divider" src="{% static 'vauhtijuoksu2021plus/img/divider_2.png' %}">
-{% elif number == 3 %}
-  <img class="divider"  alt="divider" src="{% static 'vauhtijuoksu2021plus/img/divider_3.png' %}">
-{% else %}
-  <img alt="divider" src="{% static 'vauhtijuoksu2021plus/img/divider_0.png' %}">
-{% endif %}
+<img class="divider" alt="divider" src="{% static 'vauhtijuoksu2021plus/img/'|add:divider_name %}">

--- a/templates/vauhtijuoksu/plugins/floatychars.html
+++ b/templates/vauhtijuoksu/plugins/floatychars.html
@@ -2,7 +2,7 @@
 
 <div class="float_chars">
     {% for char in chars %}
-        <img class="char floaty" src="{% static "vauhtijuoksu2021plus/img/char/" %}{{ char.file }}" style="top: {{ char.top }}; left: {{ char.left }};  opacity: {{ char.opacity }}; transform: translate(-50%, -50%) scale({{ char.xscale }},2); animation-delay: {{ char.delay }}">
+        <img class="char floaty" src="{% static "vauhtijuoksu2021plus/img/char/"|add:char.file %}" style="top: {{ char.top }}; left: {{ char.left }};  opacity: {{ char.opacity }}; transform: translate(-50%, -50%) scale({{ char.xscale }},2); animation-delay: {{ char.delay }}">
     {% endfor %}
 </div>
 <script>

--- a/templates/vauhtijuoksu/plugins/tabletimetable.html
+++ b/templates/vauhtijuoksu/plugins/tabletimetable.html
@@ -44,7 +44,7 @@
                 {% for game in day %}
                     <div class="tttgame {{ game.cut_style }}" style="top: {{ game.start_percent }}%; bottom: {{ game.end_percent }}%">
                         <div>
-                            <div class="tttimg"><img src="{% static "vauhtijuoksu2021plus/img/char/" %}{{ game.img_filename }}"></div>
+                            <div class="tttimg"><img src="{% static "vauhtijuoksu2021plus/img/char/"|add:game.img_filename %}"></div>
                             <div>
                                 <p>
                                 {{ game.game }}

--- a/templates/vauhtijuoksu/plugins/timetable.html
+++ b/templates/vauhtijuoksu/plugins/timetable.html
@@ -14,7 +14,7 @@
                 </div>
                 <div class="playblob">
                     <div class="timetable-char">
-                        <img class="char" src="{% static "vauhtijuoksu2021plus/img/char/" %}{{ game.img_filename }}">
+                        <img class="char" src="{% static "vauhtijuoksu2021plus/img/char/"|add:game.img_filename %}">
                     </div>
                 </div>
                 <div class="playright">

--- a/vj_cms/cms_plugins.py
+++ b/vj_cms/cms_plugins.py
@@ -17,7 +17,7 @@ class DividerPlugin(CMSPluginBase):
 
     def render(self, context, instance, placeholder):
         context = super().render(context, instance, placeholder)
-        context['number'] = randint(0, 3)
+        context['divider_name'] = f'divider_{randint(0, 3)}.png'
         return context
 
 @plugin_pool.register_plugin


### PR DESCRIPTION
Changed static tags to include entire image name instead of just directory path, which enables more aggressive cache strategies due to hash-equipped filenames.

Also included:
* Simplified divider plugin logic
* Added github actions configuration for staging deployment (should not affect production)