### PR TITLE
Fix CMS plugin caching & CSRF token

### DIFF
--- a/marathon/cms_plugins.py
+++ b/marathon/cms_plugins.py
@@ -9,6 +9,7 @@ class SubmissionListPlugin(CMSPluginBase):
     name = 'Submission List'
     model = MarathonPlugin
     render_template = 'marathon/plugins/submission_list.html'
+    cache = False
 
     def render(self, context, instance, placeholder):
         context = super().render(context, instance, placeholder)
@@ -27,6 +28,7 @@ class SubmissionFormPlugin(CMSPluginBase):
     name = 'Submission Form'
     model = MarathonPlugin
     render_template = 'marathon/plugins/submission_form.html'
+    cache = False
 
     def render(self, context, instance, placeholder):
         context = super().render(context, instance, placeholder)

--- a/templates/generic_base.html
+++ b/templates/generic_base.html
@@ -17,7 +17,6 @@
   {% block body %}{% endblock %}
 
   {% render_block "js" %}
-  </main>
 </body>
 
 </html>

--- a/vauhtijuoksu/settings/base.py
+++ b/vauhtijuoksu/settings/base.py
@@ -67,7 +67,7 @@ MIDDLEWARE = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    # 'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
* Disabled caching for marathon submission form CMS plugin (CSRF token is always fresh)
* Disabled caching for marathon submission list plugin (runs are always updated)
* Reenabled CSRF token middleware (as token is now fresh)