### PR TITLE
Hotfix: Generate sha docker tag only for branch pushes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,8 +32,9 @@ jobs:
           images: |
             name=${{ secrets.ACR_ENDPOINT}}/vauhtijuoksu/cms
           tags: |
-            # sha for all triggers
-            type=sha,prefix={{branch}}-
+            # sha for branch triggers
+            type=ref,event=branch
+            type=ref,event=branch,suffix=-{{sha}}
             # semver only for version tags
             type=semver,pattern={{version}}
 


### PR DESCRIPTION
Docker workflow was breaking on `push tag` event because it does not have a `{{branch}}` ref associated and tags starting with dash are not allowed (e.g. `{{branch}}-{{sha}}` would result in `-asdf123` which fails).

This fixes the tag generation for `-{{sha}}` tags to only trigger for branch pushes and pull requests.