### PR TITLE
Use wildcard cert in production

### DIFF
--- a/deployment/templates/ingress.yaml
+++ b/deployment/templates/ingress.yaml
@@ -10,7 +10,6 @@ spec:
         {{- range .Values.http.hosts }}
         - {{ . }}
         {{- end }}
-      secretName: cms-tls
   ingressClassName: traefik
   rules:
     {{- $svc := .Chart.Name }}

--- a/deployment/templates/nginx-ingress.yaml
+++ b/deployment/templates/nginx-ingress.yaml
@@ -8,7 +8,6 @@ spec:
   tls:
     - hosts:
         - {{ .Values.http.staticfiles_host }}
-      secretName: {{ .Values.http.staticfiles_host }}
   ingressClassName: traefik
   rules:
     - host: {{ .Values.http.staticfiles_host }}


### PR DESCRIPTION
Drop secretName field in Ingresses to rely on wildcard cert that is used in production.